### PR TITLE
Cleaner IMC + removed Tcon Reflection

### DIFF
--- a/src/main/java/buildcraftAdditions/BuildcraftAdditions.java
+++ b/src/main/java/buildcraftAdditions/BuildcraftAdditions.java
@@ -1,14 +1,9 @@
 package buildcraftAdditions;
 
-import com.google.common.collect.ImmutableList;
-
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.StringUtils;
-
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
@@ -20,10 +15,10 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.util.Constants;
 
 import buildcraftAdditions.ModIntegration.ModIntegration;
 import buildcraftAdditions.ModIntegration.imc.IMCHandler;
+import buildcraftAdditions.ModIntegration.imc.IMCSender;
 import buildcraftAdditions.api.item.BCAItemManager;
 import buildcraftAdditions.api.item.dust.IDust;
 import buildcraftAdditions.api.recipe.BCARecipeManager;
@@ -76,6 +71,16 @@ public class BuildcraftAdditions {
 	}
 
 	@Mod.EventHandler
+	public void load(FMLInitializationEvent event) {
+		proxy.registerRenderers();
+		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
+		FMLCommonHandler.instance().bus().register(new EventListener.FML());
+		MinecraftForge.EVENT_BUS.register(new EventListener.Forge());
+
+		IMCSender.sendMessages();
+	}
+
+	@Mod.EventHandler
 	public void doneLoading(FMLLoadCompleteEvent event) {
 		ItemsAndBlocks.addRecipes();
 
@@ -103,14 +108,6 @@ public class BuildcraftAdditions {
 		}
 
 		IMCHandler.handleIMC(FMLInterModComms.fetchRuntimeMessages(this));
-	}
-
-	@Mod.EventHandler
-	public void load(FMLInitializationEvent event) {
-		proxy.registerRenderers();
-		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
-		FMLCommonHandler.instance().bus().register(new EventListener.FML());
-		MinecraftForge.EVENT_BUS.register(new EventListener.Forge());
 	}
 
 	@Mod.EventHandler

--- a/src/main/java/buildcraftAdditions/BuildcraftAdditions.java
+++ b/src/main/java/buildcraftAdditions/BuildcraftAdditions.java
@@ -23,6 +23,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
 
 import buildcraftAdditions.ModIntegration.ModIntegration;
+import buildcraftAdditions.ModIntegration.imc.IMCHandler;
 import buildcraftAdditions.api.item.BCAItemManager;
 import buildcraftAdditions.api.item.dust.IDust;
 import buildcraftAdditions.api.recipe.BCARecipeManager;
@@ -101,7 +102,7 @@ public class BuildcraftAdditions {
 			}
 		}
 
-		processIMC(FMLInterModComms.fetchRuntimeMessages(this));
+		IMCHandler.handleIMC(FMLInterModComms.fetchRuntimeMessages(this));
 	}
 
 	@Mod.EventHandler
@@ -114,37 +115,6 @@ public class BuildcraftAdditions {
 
 	@Mod.EventHandler
 	public void onIMC(FMLInterModComms.IMCEvent event) {
-		processIMC(event.getMessages());
-	}
-
-	private void processIMC(ImmutableList<FMLInterModComms.IMCMessage> messages) {
-		for (FMLInterModComms.IMCMessage message : messages) {
-			if ("addDusting".equalsIgnoreCase(message.key) && message.isNBTMessage() && message.getNBTValue().hasKey("output", Constants.NBT.TAG_COMPOUND)) {
-				NBTTagCompound nbt = message.getNBTValue().getCompoundTag("output");
-				if (nbt != null) {
-					ItemStack output = ItemStack.loadItemStackFromNBT(nbt);
-					if (output != null) {
-						if (message.getNBTValue().hasKey("input", Constants.NBT.TAG_COMPOUND)) {
-							nbt = message.getNBTValue().getCompoundTag("input");
-							if (nbt != null) {
-								ItemStack input = ItemStack.loadItemStackFromNBT(nbt);
-								if (input != null) {
-									BCARecipeManager.duster.addRecipe(input, output);
-									continue;
-								}
-							}
-						}
-						if (message.getNBTValue().hasKey("oreInput", Constants.NBT.TAG_STRING)) {
-							String oreInput = nbt.getString("oreInput");
-							if (!StringUtils.isNullOrEmpty(oreInput)) {
-								BCARecipeManager.duster.addRecipe(oreInput, output);
-								continue;
-							}
-						}
-					}
-				}
-			}
-			Logger.error("The mod '" + message.getSender() + "' send an invalid IMC message (" + message.key + ") ! Skipping.");
-		}
+		IMCHandler.handleIMC(event.getMessages());
 	}
 }

--- a/src/main/java/buildcraftAdditions/ModIntegration/ModIntegration.java
+++ b/src/main/java/buildcraftAdditions/ModIntegration/ModIntegration.java
@@ -50,8 +50,6 @@ public class ModIntegration {
 		RefineryRecipeConverter.doYourThing();
 		if (Loader.isModLoaded("MineTweaker3"))
 			MineTweakerIntegreation.integrate();
-		if (Loader.isModLoaded("TConstruct"))
-			tinkersConstructIntegration();
 		if (Loader.isModLoaded("BuildCraft|Transport")) {
 			BuildcraftIntegration.integrate();
 		}
@@ -62,20 +60,6 @@ public class ModIntegration {
 		addNuggets("Gold");
 		addNuggets("Copper");
 		addNuggets("Tin");
-	}
-
-	private static void tinkersConstructIntegration() { //NOTE: this will crash when a battery is placed on the tool for every TCon version before the 681 jenkins build! will be fixed
-		try {
-			Class<?> toolsClass = Class.forName("tconstruct.tools.TinkerTools");
-			Object modifier = toolsClass.getField("modFlux").get(null);
-			Class<?> modifierClass = Class.forName("tconstruct.modifiers.tools.ModFlux");
-			List<ItemStack> batteries = (List<ItemStack>) modifierClass.getField("batteries").get(modifier);
-			batteries.add(new ItemStack(ItemsAndBlocks.powerCapsuleTier1));
-			batteries.add(new ItemStack(ItemsAndBlocks.powerCapsuleTier2));
-			batteries.add(new ItemStack(ItemsAndBlocks.powerCapsuleTier3));
-		} catch (Exception e) {
-			Logger.error("power capsule haven't been initialized to TinkersConstruct's Flux Modifier, this is a bug!");
-		}
 	}
 
 	private static void eurekaResearch() {

--- a/src/main/java/buildcraftAdditions/ModIntegration/imc/IMCHandler.java
+++ b/src/main/java/buildcraftAdditions/ModIntegration/imc/IMCHandler.java
@@ -1,0 +1,87 @@
+package buildcraftAdditions.ModIntegration.imc;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import cpw.mods.fml.common.event.FMLInterModComms;
+
+import net.minecraftforge.common.util.Constants;
+
+import buildcraftAdditions.api.recipe.BCARecipeManager;
+import buildcraftAdditions.core.Logger;
+
+import com.google.common.base.Strings;
+
+/**
+ * Copyright (c) 2014, AEnterprise
+ * http://buildcraftadditions.wordpress.com/
+ * Buildcraft Additions is distributed under the terms of GNU GPL v3.0
+ * Please check the contents of the license located in
+ * http://buildcraftadditions.wordpress.com/wiki/licensing-stuff/
+ */
+public class IMCHandler {
+
+	public static void handleIMC(List<FMLInterModComms.IMCMessage> messages) {
+
+		for (FMLInterModComms.IMCMessage message : messages) {
+			String type = message.key;
+
+			if (Strings.isNullOrEmpty(type))
+				continue;
+
+			if (type.equals("addDusting")) {
+				if (!message.isNBTMessage()) {
+					logNotNBT(message);
+					continue;
+				}
+
+				NBTTagCompound tag = message.getNBTValue();
+				if (!checkRequiredNBTTags("Dusting", tag, "Input", "Output"))
+					continue;
+
+				ItemStack output = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("Output"));
+				if (output == null)
+					return;
+
+				if (tag.getCompoundTag("Input").hasKey("id", Constants.NBT.TAG_SHORT)) {
+					ItemStack input = ItemStack.loadItemStackFromNBT(tag.getCompoundTag("Input"));
+					if (input != null)
+						BCARecipeManager.duster.addRecipe(input, output);
+				} else if (tag.hasKey("Input", Constants.NBT.TAG_STRING)) {
+					if (!Strings.isNullOrEmpty(tag.getString("Input")))
+						BCARecipeManager.duster.addRecipe(tag.getString("Input"), output);
+				}
+			}
+		}
+	}
+
+	protected static void logNotNBT(FMLInterModComms.IMCMessage message) {
+		logInvalidMessage(message, "NBT");
+	}
+
+	protected static void logNotItemStack(FMLInterModComms.IMCMessage message) {
+		logInvalidMessage(message, "ItemStack");
+	}
+
+	protected static void logNotString(FMLInterModComms.IMCMessage message) {
+		logInvalidMessage(message, "String");
+	}
+
+	protected static void logInvalidMessage(FMLInterModComms.IMCMessage message, String type) {
+		Logger.error(String.format("Received and invalid IMC message : '%s' from '%s'. This message is not of the '%s' type!", message.key, message.getSender(), type));
+	}
+
+	protected static boolean checkRequiredNBTTags(String key, NBTTagCompound tag, String... requiredArgs) {
+		boolean fine = true;
+		for (String arg : requiredArgs) {
+			if (!tag.hasKey(arg)) {
+				Logger.error(String.format("%s IMC: Missing required NBT Tag '%s'", key, arg));
+				fine = false;
+			}
+		}
+
+		return fine;
+	}
+}

--- a/src/main/java/buildcraftAdditions/ModIntegration/imc/IMCSender.java
+++ b/src/main/java/buildcraftAdditions/ModIntegration/imc/IMCSender.java
@@ -1,0 +1,20 @@
+package buildcraftAdditions.ModIntegration.imc;
+
+import net.minecraft.item.ItemStack;
+
+import cpw.mods.fml.common.event.FMLInterModComms;
+
+import buildcraftAdditions.reference.ItemsAndBlocks;
+
+public class IMCSender {
+
+	public static void sendMessages() {
+		tinkersConstruct();
+	}
+
+	protected static void tinkersConstruct() {
+		FMLInterModComms.sendMessage("TConstruct", "addFluxBattery", new ItemStack(ItemsAndBlocks.powerCapsuleTier1));
+		FMLInterModComms.sendMessage("TConstruct", "addFluxBattery", new ItemStack(ItemsAndBlocks.powerCapsuleTier2));
+		FMLInterModComms.sendMessage("TConstruct", "addFluxBattery", new ItemStack(ItemsAndBlocks.powerCapsuleTier3));
+	}
+}


### PR DESCRIPTION
Added a cleaner way of checking and sending IMC messages and changed the reflection that added the energy capacitors to a nice simple IMC message which should start working when TinkersConstruct 1.8.3 gets released.